### PR TITLE
chore: replace moq with nsubstitute

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.4.1" />
     <PackageVersion Include="Radzen.Blazor" Version="5.9.8" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />

--- a/tests/Visus.AddressValidation.Integration.Google.Tests/GoogleAuthenticationServiceFacts.cs
+++ b/tests/Visus.AddressValidation.Integration.Google.Tests/GoogleAuthenticationServiceFacts.cs
@@ -1,3 +1,5 @@
+using NSubstitute;
+
 namespace Visus.AddressValidation.Integration.Google.Tests;
 
 using System.Text.Json;
@@ -6,7 +8,6 @@ using Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using Moq;
 using RichardSzalay.MockHttp;
 using Services;
 
@@ -55,7 +56,7 @@ public sealed class GoogleAuthenticationServiceFacts(ConfigurationFixture fixtur
 			TokenType = "Bearer"
 		};
 
-		var distributedCacheMock = new Mock<IDistributedCache>();
+		var distributedCacheMock = Substitute.For<IDistributedCache>();
 
 		var httpMessageHandlerMock = new MockHttpMessageHandler();
 		httpMessageHandlerMock.Expect("https://oauth2.googleapis.com/token")
@@ -64,7 +65,7 @@ public sealed class GoogleAuthenticationServiceFacts(ConfigurationFixture fixtur
 
 		var httpClient = httpMessageHandlerMock.ToHttpClient();
 		var client = new GoogleAuthenticationClient(_fixture.Configuration, httpClient);
-		var service = new GoogleAuthenticationService(distributedCacheMock.Object, _fixture.Configuration, client);
+		var service = new GoogleAuthenticationService(distributedCacheMock, _fixture.Configuration, client);
 
 		var result = await service.GetAccessTokenAsync();
 

--- a/tests/Visus.AddressValidation.Integration.Google.Tests/Visus.AddressValidation.Integration.Google.Tests.csproj
+++ b/tests/Visus.AddressValidation.Integration.Google.Tests/Visus.AddressValidation.Integration.Google.Tests.csproj
@@ -16,7 +16,7 @@
 		</PackageReference>
 		<PackageReference Include="JunitXml.TestLogger"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="Moq"/>
+		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="PublicApiGenerator"/>
 		<PackageReference Include="RichardSzalay.MockHttp"/>
 		<PackageReference Include="Verify.Xunit"/>

--- a/tests/Visus.AddressValidation.Integration.Google.Tests/packages.lock.json
+++ b/tests/Visus.AddressValidation.Integration.Google.Tests/packages.lock.json
@@ -30,11 +30,11 @@
           "Microsoft.TestPlatform.TestHost": "17.12.0"
         }
       },
-      "Moq": {
+      "NSubstitute": {
         "type": "Direct",
-        "requested": "[4.20.72, )",
-        "resolved": "4.20.72",
-        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }

--- a/tests/Visus.AddressValidation.Integration.PitneyBowes.Tests/PitneyBowesAuthenticationServiceFacts.cs
+++ b/tests/Visus.AddressValidation.Integration.PitneyBowes.Tests/PitneyBowesAuthenticationServiceFacts.cs
@@ -1,3 +1,5 @@
+using NSubstitute;
+
 namespace Visus.AddressValidation.Integration.PitneyBowes.Tests;
 
 using System.Text.Json;
@@ -6,7 +8,6 @@ using Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using Moq;
 using RichardSzalay.MockHttp;
 using Services;
 
@@ -56,7 +57,7 @@ public sealed class PitneyBowesAuthenticationServiceFacts(ConfigurationFixture f
 			TokenType = "Bearer"
 		};
 
-		var distributedCacheMock = new Mock<IDistributedCache>();
+		var distributedCacheMock = Substitute.For<IDistributedCache>();
 
 		var httpMessageHandlerMock = new MockHttpMessageHandler();
 		httpMessageHandlerMock.Expect("/oauth/token")
@@ -65,7 +66,7 @@ public sealed class PitneyBowesAuthenticationServiceFacts(ConfigurationFixture f
 
 		var httpClient = httpMessageHandlerMock.ToHttpClient();
 		var client = new PitneyBowesAuthenticationClient(_fixture.Configuration, httpClient);
-		var service = new PitneyBowesAuthenticationService(distributedCacheMock.Object, _fixture.Configuration, client);
+		var service = new PitneyBowesAuthenticationService(distributedCacheMock, _fixture.Configuration, client);
 
 		var result = await service.GetAccessTokenAsync();
 

--- a/tests/Visus.AddressValidation.Integration.PitneyBowes.Tests/Visus.AddressValidation.Integration.PitneyBowes.Tests.csproj
+++ b/tests/Visus.AddressValidation.Integration.PitneyBowes.Tests/Visus.AddressValidation.Integration.PitneyBowes.Tests.csproj
@@ -16,7 +16,7 @@
 		</PackageReference>
 		<PackageReference Include="JunitXml.TestLogger"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="Moq"/>
+		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="PublicApiGenerator"/>
 		<PackageReference Include="RichardSzalay.MockHttp"/>
 		<PackageReference Include="Verify.Xunit"/>

--- a/tests/Visus.AddressValidation.Integration.PitneyBowes.Tests/packages.lock.json
+++ b/tests/Visus.AddressValidation.Integration.PitneyBowes.Tests/packages.lock.json
@@ -30,11 +30,11 @@
           "Microsoft.TestPlatform.TestHost": "17.12.0"
         }
       },
-      "Moq": {
+      "NSubstitute": {
         "type": "Direct",
-        "requested": "[4.20.72, )",
-        "resolved": "4.20.72",
-        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }

--- a/tests/Visus.AddressValidation.Integration.Ups.Tests/UpsAuthenticationServiceFacts.cs
+++ b/tests/Visus.AddressValidation.Integration.Ups.Tests/UpsAuthenticationServiceFacts.cs
@@ -1,3 +1,6 @@
+using NSubstitute;
+using NSubstitute.Exceptions;
+
 namespace Visus.AddressValidation.Integration.Ups.Tests;
 
 using System.Text.Json;
@@ -6,7 +9,6 @@ using Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using Moq;
 using RichardSzalay.MockHttp;
 using Services;
 
@@ -56,7 +58,7 @@ public sealed class UpsAuthenticationServiceFacts(ConfigurationFixture fixture) 
 			TokenType = "Bearer"
 		};
 
-		var distributedCacheMock = new Mock<IDistributedCache>();
+		var distributedCacheMock = Substitute.For<IDistributedCache>();
 
 		var httpMessageHandlerMock = new MockHttpMessageHandler();
 		httpMessageHandlerMock.Expect("/security/v1/oauth/token")
@@ -66,7 +68,7 @@ public sealed class UpsAuthenticationServiceFacts(ConfigurationFixture fixture) 
 
 		var httpClient = httpMessageHandlerMock.ToHttpClient();
 		var client = new UpsAuthenticationClient(_fixture.Configuration, httpClient);
-		var service = new UpsAuthenticationService(distributedCacheMock.Object, _fixture.Configuration, client);
+		var service = new UpsAuthenticationService(distributedCacheMock, _fixture.Configuration, client);
 
 		var result = await service.GetAccessTokenAsync();
 

--- a/tests/Visus.AddressValidation.Integration.Ups.Tests/Visus.AddressValidation.Integration.Ups.Tests.csproj
+++ b/tests/Visus.AddressValidation.Integration.Ups.Tests/Visus.AddressValidation.Integration.Ups.Tests.csproj
@@ -16,7 +16,7 @@
 		</PackageReference>
 		<PackageReference Include="JunitXml.TestLogger"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="Moq"/>
+		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="PublicApiGenerator"/>
 		<PackageReference Include="RichardSzalay.MockHttp"/>
 		<PackageReference Include="Verify.Xunit"/>

--- a/tests/Visus.AddressValidation.Integration.Ups.Tests/packages.lock.json
+++ b/tests/Visus.AddressValidation.Integration.Ups.Tests/packages.lock.json
@@ -30,11 +30,11 @@
           "Microsoft.TestPlatform.TestHost": "17.12.0"
         }
       },
-      "Moq": {
+      "NSubstitute": {
         "type": "Direct",
-        "requested": "[4.20.72, )",
-        "resolved": "4.20.72",
-        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }

--- a/tests/Visus.AddressValidation.Tests/Http/Authentication/BearerTokenDelegatingHandlerFacts.cs
+++ b/tests/Visus.AddressValidation.Tests/Http/Authentication/BearerTokenDelegatingHandlerFacts.cs
@@ -1,9 +1,10 @@
+using NSubstitute;
+
 namespace Visus.AddressValidation.Tests.Http.Authentication;
 
 using Abstractions;
 using AddressValidation.Http;
 using Microsoft.Extensions.Caching.Distributed;
-using Moq;
 using Services;
 
 public sealed class BearerTokenDelegatingHandlerFacts : DelegatingHandlerFacts
@@ -13,9 +14,9 @@ public sealed class BearerTokenDelegatingHandlerFacts : DelegatingHandlerFacts
 	{
 		const string accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
-		var distributedCacheMock = new Mock<IDistributedCache>();
+		var distributedCacheMock = Substitute.For<IDistributedCache>();
 		var authenticationClient = new TestAuthenticationClient();
-		var authenticationService = new TestAuthenticationService(authenticationClient, distributedCacheMock.Object);
+		var authenticationService = new TestAuthenticationService(authenticationClient, distributedCacheMock);
 
 		var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://localhost");
 		var handler = new BearerTokenDelegatingHandler<TestAuthenticationClient>(authenticationService)

--- a/tests/Visus.AddressValidation.Tests/Visus.AddressValidation.Tests.csproj
+++ b/tests/Visus.AddressValidation.Tests/Visus.AddressValidation.Tests.csproj
@@ -16,7 +16,7 @@
 		</PackageReference>
 		<PackageReference Include="JunitXml.TestLogger"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="Moq"/>
+		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="PublicApiGenerator"/>
 		<PackageReference Include="Verify.Xunit"/>
 		<PackageReference Include="xunit"/>

--- a/tests/Visus.AddressValidation.Tests/packages.lock.json
+++ b/tests/Visus.AddressValidation.Tests/packages.lock.json
@@ -30,11 +30,11 @@
           "Microsoft.TestPlatform.TestHost": "17.12.0"
         }
       },
-      "Moq": {
+      "NSubstitute": {
         "type": "Direct",
-        "requested": "[4.20.72, )",
-        "resolved": "4.20.72",
-        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }


### PR DESCRIPTION
# Description

Replace the dependency on the library [Moq](https://github.com/moq) with [NSubstitute](https://github.com/nsubstitute/NSubstitute) due to privacy concerns.