### PR TITLE
refactor(integrations): move to explicit constructor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -104,6 +104,11 @@ csharp_style_unused_value_expression_statement_preference = discard_variable
 # 'using' directive preferences
 csharp_using_directive_placement = inside_namespace
 
+# Constructor Preferences
+csharp_style_prefer_primary_constructors = false
+dotnet_diagnostic.IDE0290.severity = none
+resharper_convert_to_primary_constructor_highlighting = none
+
 #### C# Formatting Rules ####
 
 # New line preferences

--- a/src/Visus.AddressValidation.Integration.Google/Http/GoogleAuthenticationClient.cs
+++ b/src/Visus.AddressValidation.Integration.Google/Http/GoogleAuthenticationClient.cs
@@ -10,14 +10,19 @@ using AddressValidation.Serialization.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
-internal sealed class GoogleAuthenticationClient(IConfiguration configuration, HttpClient httpClient)
-    : IAuthenticationClient
+internal sealed class GoogleAuthenticationClient : IAuthenticationClient
 {
     private static readonly Uri AuthenticationUrl = new("https://oauth2.googleapis.com/token");
 
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
 
-    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private readonly HttpClient _httpClient;
+
+    public GoogleAuthenticationClient(IConfiguration configuration, HttpClient httpClient)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
 
     public async ValueTask<TokenResponse?> RequestClientCredentialsTokenAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Visus.AddressValidation.Integration.Google/Services/AddressValidationService.cs
+++ b/src/Visus.AddressValidation.Integration.Google/Services/AddressValidationService.cs
@@ -4,13 +4,17 @@ using AddressValidation.Services;
 using AddressValidation.Validation;
 using Http;
 
-internal sealed class AddressValidationService(
-    GoogleAddressValidationClient client,
-    IValidator<GoogleAddressValidationRequest> requestValidator,
-    IValidator<ApiResponse> responseValidator)
-    : AbstractAddressValidationService<GoogleAddressValidationRequest, ApiResponse>(requestValidator, responseValidator)
+internal sealed class AddressValidationService : AbstractAddressValidationService<GoogleAddressValidationRequest, ApiResponse>
 {
-    private readonly GoogleAddressValidationClient _client = client ?? throw new ArgumentNullException(nameof(client));
+    private readonly GoogleAddressValidationClient _client;
+
+    public AddressValidationService(GoogleAddressValidationClient client,
+                                    IValidator<GoogleAddressValidationRequest> requestValidator,
+                                    IValidator<ApiResponse> responseValidator)
+        : base(requestValidator, responseValidator)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
 
     protected override async ValueTask<ApiResponse?> SendAsync(GoogleAddressValidationRequest request, CancellationToken cancellationToken)
     {

--- a/src/Visus.AddressValidation.Integration.Google/Services/GoogleAuthenticationService.cs
+++ b/src/Visus.AddressValidation.Integration.Google/Services/GoogleAuthenticationService.cs
@@ -5,13 +5,17 @@ using Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 
-internal sealed class GoogleAuthenticationService(
-    IDistributedCache cache,
-    IConfiguration configuration,
-    GoogleAuthenticationClient authenticationClient)
-    : AbstractAuthenticationService<GoogleAuthenticationClient>(authenticationClient, cache)
+internal sealed class GoogleAuthenticationService : AbstractAuthenticationService<GoogleAuthenticationClient>
 {
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
+
+    public GoogleAuthenticationService(IDistributedCache cache,
+                                       IConfiguration configuration,
+                                       GoogleAuthenticationClient authenticationClient) 
+        : base(authenticationClient, cache)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
 
     protected override string? GenerateCacheKey()
     {

--- a/src/Visus.AddressValidation.Integration.PitneyBowes/Http/PitneyBowesAddressValidationClient.cs
+++ b/src/Visus.AddressValidation.Integration.PitneyBowes/Http/PitneyBowesAddressValidationClient.cs
@@ -6,13 +6,18 @@ using AddressValidation.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Serialization.Json;
 
-internal sealed class PitneyBowesAddressValidationClient(
-    IConfiguration configuration,
-    HttpClient httpClient)
+internal sealed class PitneyBowesAddressValidationClient
 {
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
 
-    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private readonly HttpClient _httpClient;
+
+    public PitneyBowesAddressValidationClient(IConfiguration configuration,
+                                              HttpClient httpClient)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<ApiResponse?> ValidateAddressAsync(PitneyBowesAddressValidationRequest request, CancellationToken cancellationToken = default)

--- a/src/Visus.AddressValidation.Integration.PitneyBowes/Http/PitneyBowesAuthenticationClient.cs
+++ b/src/Visus.AddressValidation.Integration.PitneyBowes/Http/PitneyBowesAuthenticationClient.cs
@@ -6,12 +6,17 @@ using AddressValidation.Http;
 using AddressValidation.Serialization.Json;
 using Microsoft.Extensions.Configuration;
 
-internal sealed class PitneyBowesAuthenticationClient(IConfiguration configuration, HttpClient httpClient)
-    : IAuthenticationClient
+internal sealed class PitneyBowesAuthenticationClient : IAuthenticationClient
 {
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
 
-    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private readonly HttpClient _httpClient;
+
+    public PitneyBowesAuthenticationClient(IConfiguration configuration, HttpClient httpClient)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
 
     public async ValueTask<TokenResponse?> RequestClientCredentialsTokenAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Visus.AddressValidation.Integration.PitneyBowes/Services/AddressValidationService.cs
+++ b/src/Visus.AddressValidation.Integration.PitneyBowes/Services/AddressValidationService.cs
@@ -4,13 +4,17 @@ using AddressValidation.Services;
 using AddressValidation.Validation;
 using Http;
 
-internal sealed class AddressValidationService(
-    PitneyBowesAddressValidationClient client,
-    IValidator<PitneyBowesAddressValidationRequest> requestValidator,
-    IValidator<ApiResponse> responseValidator)
-    : AbstractAddressValidationService<PitneyBowesAddressValidationRequest, ApiResponse>(requestValidator, responseValidator)
+internal sealed class AddressValidationService : AbstractAddressValidationService<PitneyBowesAddressValidationRequest, ApiResponse>
 {
-    private readonly PitneyBowesAddressValidationClient _client = client ?? throw new ArgumentNullException(nameof(client));
+    private readonly PitneyBowesAddressValidationClient _client;
+
+    public AddressValidationService(PitneyBowesAddressValidationClient client,
+                                    IValidator<PitneyBowesAddressValidationRequest> requestValidator,
+                                    IValidator<ApiResponse> responseValidator) 
+        : base(requestValidator, responseValidator)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
 
     protected override async ValueTask<ApiResponse?> SendAsync(PitneyBowesAddressValidationRequest request, CancellationToken cancellationToken)
     {

--- a/src/Visus.AddressValidation.Integration.PitneyBowes/Services/PitneyBowesAuthenticationService.cs
+++ b/src/Visus.AddressValidation.Integration.PitneyBowes/Services/PitneyBowesAuthenticationService.cs
@@ -6,13 +6,17 @@ using Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 
-internal sealed class PitneyBowesAuthenticationService(
-    IDistributedCache cache,
-    IConfiguration configuration,
-    PitneyBowesAuthenticationClient authenticationClient)
-    : AbstractAuthenticationService<PitneyBowesAuthenticationClient>(authenticationClient, cache)
+internal sealed class PitneyBowesAuthenticationService : AbstractAuthenticationService<PitneyBowesAuthenticationClient>
 {
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
+
+    public PitneyBowesAuthenticationService(IDistributedCache cache,
+                                            IConfiguration configuration,
+                                            PitneyBowesAuthenticationClient authenticationClient) 
+        : base(authenticationClient, cache)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
 
     protected override string? GenerateCacheKey()
     {

--- a/src/Visus.AddressValidation.Integration.Ups/Http/UpsAddressValidationClient.cs
+++ b/src/Visus.AddressValidation.Integration.Ups/Http/UpsAddressValidationClient.cs
@@ -6,13 +6,18 @@ using AddressValidation.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Serialization.Json;
 
-internal sealed class UpsAddressValidationClient(
-    IConfiguration configuration,
-    HttpClient httpClient)
+internal sealed class UpsAddressValidationClient
 {
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
 
-    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private readonly HttpClient _httpClient;
+
+    public UpsAddressValidationClient(IConfiguration configuration,
+                                      HttpClient httpClient)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<ApiResponse?> ValidateAddressAsync(UpsAddressValidationRequest request, CancellationToken cancellationToken = default)

--- a/src/Visus.AddressValidation.Integration.Ups/Http/UpsAuthenticationClient.cs
+++ b/src/Visus.AddressValidation.Integration.Ups/Http/UpsAuthenticationClient.cs
@@ -6,12 +6,17 @@ using AddressValidation.Http;
 using AddressValidation.Serialization.Json;
 using Microsoft.Extensions.Configuration;
 
-internal sealed class UpsAuthenticationClient(IConfiguration configuration, HttpClient httpClient)
-    : IAuthenticationClient
+internal sealed class UpsAuthenticationClient : IAuthenticationClient
 {
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
 
-    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private readonly HttpClient _httpClient;
+
+    public UpsAuthenticationClient(IConfiguration configuration, HttpClient httpClient)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
 
     public async ValueTask<TokenResponse?> RequestClientCredentialsTokenAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Visus.AddressValidation.Integration.Ups/Services/AddressValidationService.cs
+++ b/src/Visus.AddressValidation.Integration.Ups/Services/AddressValidationService.cs
@@ -4,13 +4,17 @@ using AddressValidation.Services;
 using AddressValidation.Validation;
 using Http;
 
-internal sealed class AddressValidationService(
-    UpsAddressValidationClient client,
-    IValidator<UpsAddressValidationRequest> requestValidator,
-    IValidator<ApiResponse> responseValidator)
-    : AbstractAddressValidationService<UpsAddressValidationRequest, ApiResponse>(requestValidator, responseValidator)
+internal sealed class AddressValidationService : AbstractAddressValidationService<UpsAddressValidationRequest, ApiResponse>
 {
-    private readonly UpsAddressValidationClient _client = client ?? throw new ArgumentNullException(nameof(client));
+    private readonly UpsAddressValidationClient _client;
+
+    public AddressValidationService(UpsAddressValidationClient client,
+                                    IValidator<UpsAddressValidationRequest> requestValidator,
+                                    IValidator<ApiResponse> responseValidator) 
+        : base(requestValidator, responseValidator)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
 
     protected override async ValueTask<ApiResponse?> SendAsync(UpsAddressValidationRequest request, CancellationToken cancellationToken)
     {

--- a/src/Visus.AddressValidation.Integration.Ups/Services/UpsAuthenticationService.cs
+++ b/src/Visus.AddressValidation.Integration.Ups/Services/UpsAuthenticationService.cs
@@ -6,13 +6,17 @@ using Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 
-internal sealed class UpsAuthenticationService(
-    IDistributedCache cache,
-    IConfiguration configuration,
-    UpsAuthenticationClient authenticationClient)
-    : AbstractAuthenticationService<UpsAuthenticationClient>(authenticationClient, cache)
+internal sealed class UpsAuthenticationService : AbstractAuthenticationService<UpsAuthenticationClient>
 {
-    private readonly IConfiguration _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    private readonly IConfiguration _configuration;
+
+    public UpsAuthenticationService(IDistributedCache cache,
+                                    IConfiguration configuration,
+                                    UpsAuthenticationClient authenticationClient) 
+        : base(authenticationClient, cache)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
 
     protected override string? GenerateCacheKey()
     {

--- a/src/Visus.AddressValidation/Http/BearerTokenDelegatingHandler.cs
+++ b/src/Visus.AddressValidation/Http/BearerTokenDelegatingHandler.cs
@@ -8,14 +8,22 @@ using Services;
 /// <summary>
 ///     An HTTP delegate handler that injects a Bearer token into each request.
 /// </summary>
-/// <param name="authenticationService">
-///     An instance of <see cref="AbstractAuthenticationService{T}" /> that retrieves the
-///     access_token.
-/// </param>
-public sealed class BearerTokenDelegatingHandler<TClient>(AbstractAuthenticationService<TClient> authenticationService) : DelegatingHandler
+public sealed class BearerTokenDelegatingHandler<TClient> : DelegatingHandler
     where TClient : IAuthenticationClient
 {
-    private readonly AbstractAuthenticationService<TClient> _authenticationService = authenticationService ?? throw new ArgumentNullException(nameof(authenticationService));
+    private readonly AbstractAuthenticationService<TClient> _authenticationService;
+
+    /// <summary>
+    ///     An HTTP delegate handler that injects a Bearer token into each request.
+    /// </summary>
+    /// <param name="authenticationService">
+    ///     An instance of <see cref="AbstractAuthenticationService{T}" /> that retrieves the
+    ///     access_token.
+    /// </param>
+    public BearerTokenDelegatingHandler(AbstractAuthenticationService<TClient> authenticationService)
+    {
+        _authenticationService = authenticationService ?? throw new ArgumentNullException(nameof(authenticationService));
+    }
 
     /// <inheritdoc />
     /// <exception cref="InvalidCredentialException">Provided credentials were rejected by the server.</exception>

--- a/src/Visus.AddressValidation/Services/AbstractAuthenticationService.cs
+++ b/src/Visus.AddressValidation/Services/AbstractAuthenticationService.cs
@@ -8,20 +8,33 @@ using Microsoft.Extensions.Caching.Memory;
 ///     Abstraction for implementing an authentication service that relies on an
 ///     <see cref="IAuthenticationClient" /> implementation.
 /// </summary>
-/// <param name="authenticationClient">An <see cref="IAuthenticationClient" /> instance.</param>
-/// <param name="cache">An <see cref="IMemoryCache" /> instance.</param>
 /// <typeparam name="TClient">
 ///     An instance that implements the <see cref="IAuthenticationClient" />
 ///     interface.
 /// </typeparam>
-public abstract class AbstractAuthenticationService<TClient>(TClient authenticationClient, IDistributedCache cache)
-    where TClient : IAuthenticationClient
+public abstract class AbstractAuthenticationService<TClient> where TClient : IAuthenticationClient
 {
-    private readonly TClient _authenticationClient = authenticationClient ?? throw new ArgumentNullException(nameof(authenticationClient));
+    private readonly TClient _authenticationClient;
 
-    private readonly IDistributedCache _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    private readonly IDistributedCache _cache;
 
     private string? _cacheKey;
+
+    /// <summary>
+    ///     Abstraction for implementing an authentication service that relies on an
+    ///     <see cref="IAuthenticationClient" /> implementation.
+    /// </summary>
+    /// <param name="authenticationClient">An <see cref="IAuthenticationClient" /> instance.</param>
+    /// <param name="cache">An <see cref="IMemoryCache" /> instance.</param>
+    /// <typeparam name="TClient">
+    ///     An instance that implements the <see cref="IAuthenticationClient" />
+    ///     interface.
+    /// </typeparam>
+    protected AbstractAuthenticationService(TClient authenticationClient, IDistributedCache cache)
+    {
+        _authenticationClient = authenticationClient ?? throw new ArgumentNullException(nameof(authenticationClient));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
 
     /// <summary>
     ///     Key used by the underlying cache service to retrieve the cached access token.


### PR DESCRIPTION
# Description

Migrate from primary constructor to explicit constructor to protect the immutability of dependencies.